### PR TITLE
Fixes for when request.endpoint is None.

### DIFF
--- a/example_app/app.yaml
+++ b/example_app/app.yaml
@@ -1,3 +1,3 @@
 runtime: custom
-vm: true
+env: flex
 entrypoint: custom

--- a/example_app/main.py
+++ b/example_app/main.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from flask import Flask, render_template, request
-from flask.ext.seasurf import SeaSurf
+from flask_seasurf import SeaSurf
 from flask_talisman import Talisman
 
 

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -186,7 +186,6 @@ class Talisman(object):
             self.app.debug,
             flask.request.is_secure,
             flask.request.headers.get('X-Forwarded-Proto', 'http') == 'https',
-            flask.request.endpoint is None,
         ]
 
         if self.local_options.force_https and not any(criteria):

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -147,8 +147,8 @@ class Talisman(object):
 
     def _update_local_options(self):
         """Updates view-local options with defaults or specified values."""
-        view_function = flask.current_app.view_functions[
-                flask.request.endpoint]
+        view_function = flask.current_app.view_functions.get(
+                flask.request.endpoint)
 
         view_options = getattr(
             view_function, 'talisman_view_options', {})
@@ -186,6 +186,7 @@ class Talisman(object):
             self.app.debug,
             flask.request.is_secure,
             flask.request.headers.get('X-Forwarded-Proto', 'http') == 'https',
+            flask.request.endpoint is None,
         ]
 
         if self.local_options.force_https and not any(criteria):

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -195,4 +195,9 @@ class TestTalismanExtension(unittest.TestCase):
 
     def testBadEndpoint(self):
         response = self.client.get('/bad_endpoint')
-        self.assertEqual(response.status, '404 NOT FOUND')
+        self.assertEqual(response.status_code, 302)
+        response = self.client.get('/bad_endpoint',
+                                   headers={'X-Forwarded-Proto': 'https'})
+        self.assertEqual(response.status_code, 404)
+
+

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -192,3 +192,7 @@ class TestTalismanExtension(unittest.TestCase):
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         self.assertTrue('X-Download-Options' in response.headers)
         self.assertEqual(response.headers['X-Download-Options'], 'noopen')
+
+    def testBadEndpoint(self):
+        response = self.client.get('/bad_endpoint')
+        self.assertEqual(response.status, '404 NOT FOUND')


### PR DESCRIPTION
This patch is so that when `request.endpoint is None`:

* Don't raise 500 error.
* Don't redirect to https.

Currently, a request to an endpoint that does not exist will cause an error. I noticed this when I migrated an app engine flexible environment application from `vm: true` to `env: flex` and the health checks (requests to /_ah/health) were resulting in errors. I think the expected behavior should be that these or other nonexistent endpoints simply return 404, so I also added to the list of criteria to exclude when forcing https.

