### PR TITLE
Add referrer policy security header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,6 +36,9 @@ The default configuration:
    prevent Cross Site Scripting (XSS) attacks. This is probably the only
    setting that you should reasonably change. See the
    `Content Security Policy`_ section.
+-  Sets a strict `Referrer-Policy <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy>`_
+   of ``strict-origin-when-cross-origin`` that governs which referrer information should be included with
+   requests made.
 
 In addition to Talisman, you **should always use a cross-site request
 forgery (CSRF) library**. It's highly recommended to use
@@ -96,6 +99,10 @@ Options
 -  ``content_security_policy_report_uri``, default ``None``, a string
    indicating the report URI used for `CSP violation reports
    <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Using_CSP_violation_reports>`_
+-  ``referrer_policy``, default ``strict-origin-when-cross-origin``, a string
+   that sets the Referrer Policy header to send a full URL when performing a same-origin
+   request, only send the origin of the document to an equally secure destination
+   (HTTPS->HTTPS), and send no header to a less secure destination (HTTPS->HTTP).
 -  ``session_cookie_secure``, default ``True``, set the session cookie
    to ``secure``, preventing it from being sent over plain ``http``.
 -  ``session_cookie_http_only``, default ``True``, set the session

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -22,6 +22,8 @@ SAMEORIGIN = 'SAMEORIGIN'
 ALLOW_FROM = 'ALLOW-FROM'
 ONE_YEAR_IN_SECS = 31556926
 
+DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin'
+
 DEFAULT_CSP_POLICY = {
     'default-src': '\'self\'',
 }
@@ -67,6 +69,7 @@ class Talisman(object):
             content_security_policy=DEFAULT_CSP_POLICY,
             content_security_policy_report_uri=None,
             content_security_policy_report_only=False,
+            referrer_policy=DEFAULT_REFERRER_POLICY,
             session_cookie_secure=True,
             session_cookie_http_only=True):
         """
@@ -96,6 +99,8 @@ class Talisman(object):
                 as "report-only", which disables the enforcement by the browser
                 and requires a "report-uri" parameter with a backend to receive
                 the POST data
+            referrer_policy: A string describing the referrer policy for the
+                response.
             session_cookie_secure: Forces the session cookie to only be sent
                 over https. Disabled in debug mode.
             session_cookie_http_only: Prevents JavaScript from reading the
@@ -131,6 +136,8 @@ class Talisman(object):
                 'Setting content_security_policy_report_only to True also '
                 'requires a URI to be specified in '
                 'content_security_policy_report_uri')
+
+        self.referrer_policy = referrer_policy
 
         self.session_cookie_secure = session_cookie_secure
 
@@ -203,6 +210,7 @@ class Talisman(object):
         self._set_frame_options_headers(response.headers)
         self._set_content_security_policy_headers(response.headers)
         self._set_hsts_headers(response.headers)
+        self._set_referrer_policy_headers(response.headers)
         return response
 
     def _set_frame_options_headers(self, headers):
@@ -260,6 +268,9 @@ class Talisman(object):
             value += '; preload'
 
         headers['Strict-Transport-Security'] = value
+
+    def _set_referrer_policy_headers(self, headers):
+        headers['Referrer-Policy'] = self.referrer_policy
 
     def __call__(
             self,

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -44,7 +44,8 @@ class TestTalismanExtension(unittest.TestCase):
             'X-XSS-Protection': '1; mode=block',
             'X-Content-Type-Options': 'nosniff',
             'Content-Security-Policy': 'default-src \'self\'',
-            'X-Content-Security-Policy': 'default-src \'self\''
+            'X-Content-Security-Policy': 'default-src \'self\'',
+            'Referrer-Policy': 'strict-origin-when-cross-origin'
         }
 
         for key, value in iteritems(headers):


### PR DESCRIPTION
The referrer policy security header tells the browser what information about your website (URL and possibly path) is sent to a linked site. See [this blog/examples](https://scotthelme.co.uk/a-new-security-header-referrer-policy/) for more info.

There's also some useful information of the available directives [from Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Referrer-Policy). I've set the default to `'strict-origin-when-cross-origin'`, although it may want to be changed until Chrome adds handling for this (see [this issue](https://bugs.chromium.org/p/chromium/issues/detail?id=627968)).