### PR TITLE
Add support for the Feature-Policy Header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,6 +70,7 @@ There is also a full `Example App <https://github.com/GoogleCloudPlatform/flask-
 Options
 -------
 
+-  ``feature_policy``, default ``{}``, see the `Feature Policy` section.
 -  ``force_https``, default ``True``, forces all non-debug connects to
    ``https``.
 -  ``force_https_permanent``, default ``False``, uses ``301`` instead of
@@ -276,6 +277,25 @@ The nonce needs to be added to the script tag in the template:
 
 Note that the CSP directive (`script-src` in the example) to which the `nonce-...`
 source should be added needs to be defined explicitly.
+
+Feature Policy
+--------------
+
+The default feature policy is empty, as this is the default expected behaviour.
+Note that the Feature Policy is still a `draft https://wicg.github.io/feature-policy/`
+and supported in Chrome and Safari.
+
+Geolocation Example
+~~~~~~~~~~~~~~~~~~~
+
+Disable access to Geolocation interface.
+
+.. code:: python
+
+    feature_policy = {
+        'geolocation': '\'none\''
+    }
+    talisman = Talisman(app, feature_policy=feature_policy)
 
 Disclaimer
 ----------

--- a/example_app/main.py
+++ b/example_app/main.py
@@ -37,6 +37,9 @@ talisman = Talisman(
         ],
     },
     content_security_policy_nonce_in=['script-src'],
+    feature_policy={
+        'geolocation': '\'none\'',
+    }
 )
 
 

--- a/example_app/templates/index.html
+++ b/example_app/templates/index.html
@@ -41,6 +41,9 @@
 <script nonce="{{ csp_nonce() }}">
   // This one isn't
   console.log("Yay, nonce allowed to run this.")
+  navigator.geolocation.getCurrentPosition(function(position) {
+    console.log('Oh no, geolocation access should be denied');
+  });
 </script>
 
 </body>

--- a/flask_talisman/__init__.py
+++ b/flask_talisman/__init__.py
@@ -13,12 +13,13 @@
 # limitations under the License.
 
 from .talisman import (
-    ALLOW_FROM, DEFAULT_CSP_POLICY, DENY, GOOGLE_CSP_POLICY, SAMEORIGIN,
-    Talisman)
+    ALLOW_FROM, DEFAULT_CSP_POLICY, DEFAULT_FEATURE_POLICY, DENY,
+    GOOGLE_CSP_POLICY, SAMEORIGIN, Talisman)
 
 __all__ = (
     'ALLOW_FROM',
     'DEFAULT_CSP_POLICY',
+    'DEFAULT_FEATURE_POLICY',
     'DENY',
     'GOOGLE_CSP_POLICY',
     'SAMEORIGIN',

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -238,3 +238,14 @@ class TestTalismanExtension(unittest.TestCase):
         response = self.client.get('/bad_endpoint',
                                    headers={'X-Forwarded-Proto': 'https'})
         self.assertEqual(response.status_code, 404)
+
+    def testFeaturePolicy(self):
+        self.talisman.feature_policy['geolocation'] = '\'none\''
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        feature_policy = response.headers['Feature-Policy']
+        self.assertTrue('geolocation \'none\'' in feature_policy)
+
+        self.talisman.feature_policy['fullscreen'] = '\'self\' example.com'
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        feature_policy = response.headers['Feature-Policy']
+        self.assertTrue('fullscreen \'self\' example.com' in feature_policy)


### PR DESCRIPTION
The Feature Policy Header can disallow features on either self the
origin that specifies the policy; '*' resolves to the set of all origins
and 'none' to disable for all origins. The new header is still a draft,
but supported from Chrome 60 onwards the draft progress is tracked here
https://wicg.github.io/feature-policy

Closes #25