### PR TITLE
Allow disabling X-Frame-Options headers by passing `None`.

### DIFF
--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -106,7 +106,7 @@ class Talisman(object):
                 and requires a "report-uri" parameter with a backend to receive
                 the POST data
             content_security_policy_nonce_in: A list of csp sections to include
-                a per-request none value in
+                a per-request nonce value in
             referrer_policy: A string describing the referrer policy for the
                 response.
             session_cookie_secure: Forces the session cookie to only be sent
@@ -274,6 +274,8 @@ class Talisman(object):
         headers['Feature-Policy'] = policy
 
     def _set_frame_options_headers(self, headers, options):
+        if not options['frame_options']:
+            return
         headers['X-Frame-Options'] = options['frame_options']
 
         if options['frame_options'] == ALLOW_FROM:

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -89,12 +89,12 @@ class TestTalismanExtension(unittest.TestCase):
 
         # No HSTS headers for non-ssl requests
         response = self.client.get('/')
-        self.assertFalse('Strict-Transport-Security' in response.headers)
+        self.assertNotIn('Strict-Transport-Security', response.headers)
 
         # Secure request with HSTS off
         self.talisman.strict_transport_security = False
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertFalse('Strict-Transport-Security' in response.headers)
+        self.assertNotIn('Strict-Transport-Security', response.headers)
 
         # HSTS back on
         self.talisman.strict_transport_security = True
@@ -103,20 +103,18 @@ class TestTalismanExtension(unittest.TestCase):
         response = self.client.get('/', headers={
             'X-Forwarded-Proto': 'https'
         })
-        self.assertTrue('Strict-Transport-Security' in response.headers)
+        self.assertIn('Strict-Transport-Security', response.headers)
 
         # No subdomains
         self.talisman.strict_transport_security_include_subdomains = False
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertFalse(
-            'includeSubDomains' in
-            response.headers['Strict-Transport-Security'])
+        self.assertNotIn(
+            'includeSubDomains', response.headers['Strict-Transport-Security'])
 
         # Preload
         self.talisman.strict_transport_security_preload = True
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertTrue(
-            'preload' in response.headers['Strict-Transport-Security'])
+        self.assertIn('preload', response.headers['Strict-Transport-Security'])
 
     def testFrameOptions(self):
         self.talisman.frame_options = DENY
@@ -137,8 +135,8 @@ class TestTalismanExtension(unittest.TestCase):
         self.talisman.content_security_policy['image-src'] = '*'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         csp = response.headers['Content-Security-Policy']
-        self.assertTrue('default-src \'self\'' in csp)
-        self.assertTrue('image-src *' in csp)
+        self.assertIn('default-src \'self\'', csp)
+        self.assertIn('image-src *', csp)
 
         self.talisman.content_security_policy['image-src'] = [
             '\'self\'',
@@ -146,8 +144,8 @@ class TestTalismanExtension(unittest.TestCase):
         ]
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         csp = response.headers['Content-Security-Policy']
-        self.assertTrue('default-src \'self\'' in csp)
-        self.assertTrue('image-src \'self\' example.com' in csp)
+        self.assertIn('default-src \'self\'', csp)
+        self.assertIn('image-src \'self\' example.com', csp)
 
         # string policy
         self.talisman.content_security_policy = 'default-src example.com'
@@ -158,7 +156,7 @@ class TestTalismanExtension(unittest.TestCase):
         # no policy
         self.talisman.content_security_policy = False
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertFalse('Content-Security-Policy' in response.headers)
+        self.assertNotIn('Content-Security-Policy', response.headers)
 
         # string policy at initialization
         app = flask.Flask(__name__)
@@ -175,26 +173,26 @@ class TestTalismanExtension(unittest.TestCase):
         self.talisman.content_security_policy_report_uri = \
             'https://example.com'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertTrue(
-            'Content-Security-Policy-Report-Only' in response.headers)
-        self.assertTrue(
-            'X-Content-Security-Policy-Report-Only' in response.headers)
-        self.assertTrue(
-            'report-uri'
-            in response.headers['Content-Security-Policy-Report-Only'])
-        self.assertFalse('Content-Security-Policy' in response.headers)
-        self.assertFalse('X-Content-Security-Policy' in response.headers)
+        self.assertIn('Content-Security-Policy-Report-Only', response.headers)
+        self.assertIn(
+            'X-Content-Security-Policy-Report-Only', response.headers)
+        self.assertIn(
+            'report-uri',
+            response.headers['Content-Security-Policy-Report-Only']
+        )
+        self.assertNotIn('Content-Security-Policy', response.headers)
+        self.assertNotIn('X-Content-Security-Policy', response.headers)
 
         override_report_uri = 'https://report-uri.io/'
         self.talisman.content_security_policy = {
             'report-uri': override_report_uri,
         }
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertTrue(
-            'Content-Security-Policy-Report-Only' in response.headers)
-        self.assertTrue(
-            override_report_uri
-            in response.headers['Content-Security-Policy-Report-Only']
+        self.assertIn(
+            'Content-Security-Policy-Report-Only', response.headers)
+        self.assertIn(
+            override_report_uri,
+            response.headers['Content-Security-Policy-Report-Only']
         )
 
         # exception on missing report-uri when report-only
@@ -227,7 +225,7 @@ class TestTalismanExtension(unittest.TestCase):
             return 'Hello, world'
 
         response = self.client.get('/nocsp', environ_overrides=HTTPS_ENVIRON)
-        self.assertFalse('Content-Security-Policy' in response.headers)
+        self.assertNotIn('Content-Security-Policy', response.headers)
         self.assertEqual(response.headers['X-Frame-Options'], 'SAMEORIGIN')
 
     def testDecoratorForceHttps(self):
@@ -242,7 +240,7 @@ class TestTalismanExtension(unittest.TestCase):
     def testForceFileSave(self):
         self.talisman.force_file_save = True
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
-        self.assertTrue('X-Download-Options' in response.headers)
+        self.assertIn('X-Download-Options', response.headers)
         self.assertEqual(response.headers['X-Download-Options'], 'noopen')
 
     def testBadEndpoint(self):
@@ -256,12 +254,12 @@ class TestTalismanExtension(unittest.TestCase):
         self.talisman.feature_policy['geolocation'] = '\'none\''
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         feature_policy = response.headers['Feature-Policy']
-        self.assertTrue('geolocation \'none\'' in feature_policy)
+        self.assertIn('geolocation \'none\'', feature_policy)
 
         self.talisman.feature_policy['fullscreen'] = '\'self\' example.com'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         feature_policy = response.headers['Feature-Policy']
-        self.assertTrue('fullscreen \'self\' example.com' in feature_policy)
+        self.assertIn('fullscreen \'self\' example.com', feature_policy)
 
         # string policy at initialization
         app = flask.Flask(__name__)

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -129,6 +129,10 @@ class TestTalismanExtension(unittest.TestCase):
         self.assertEqual(
             response.headers['X-Frame-Options'], 'ALLOW-FROM example.com')
 
+        self.talisman.frame_options = None
+        response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertNotIn('X-Frame-Options', response.headers)
+
     def testContentSecurityPolicyOptions(self):
         self.talisman.content_security_policy['image-src'] = '*'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)


### PR DESCRIPTION
Since the [`frame-ancestors`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/frame-ancestors) directive in CSP 2 allows basically the same thing and setting the `X-Frame-Options` header with `allow-from` [isn't supported by Chrome and Safari](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options#Browser_compatibility) anyway, we might as well allow disabling it completely.