### PR TITLE
Allow passing strings for FP and CSP during initialization.

### DIFF
--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -118,8 +118,10 @@ class Talisman(object):
 
         See README.rst for a detailed description of each option.
         """
-
-        self.feature_policy = feature_policy.copy()
+        if isinstance(feature_policy, dict):
+            self.feature_policy = feature_policy.copy()
+        else:
+            self.feature_policy = feature_policy
         self.force_https = force_https
         self.force_https_permanent = force_https_permanent
 
@@ -134,7 +136,10 @@ class Talisman(object):
         self.strict_transport_security_include_subdomains = \
             strict_transport_security_include_subdomains
 
-        self.content_security_policy = content_security_policy.copy()
+        if isinstance(content_security_policy, dict):
+            self.content_security_policy = content_security_policy.copy()
+        else:
+            self.content_security_policy = content_security_policy
         self.content_security_policy_report_uri = \
             content_security_policy_report_uri
         self.content_security_policy_report_only = \

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -156,6 +156,15 @@ class TestTalismanExtension(unittest.TestCase):
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         self.assertFalse('Content-Security-Policy' in response.headers)
 
+        # string policy at initialization
+        app = flask.Flask(__name__)
+        Talisman(app, content_security_policy='default-src spam.eggs')
+        response = app.test_client().get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertIn(
+            'default-src spam.eggs',
+            response.headers['Content-Security-Policy']
+        )
+
     def testContentSecurityPolicyOptionsReport(self):
         # report-only policy
         self.talisman.content_security_policy_report_only = True
@@ -249,3 +258,9 @@ class TestTalismanExtension(unittest.TestCase):
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         feature_policy = response.headers['Feature-Policy']
         self.assertTrue('fullscreen \'self\' example.com' in feature_policy)
+
+        # string policy at initialization
+        app = flask.Flask(__name__)
+        Talisman(app, feature_policy='vibrate \'none\'')
+        response = app.test_client().get('/', environ_overrides=HTTPS_ENVIRON)
+        self.assertIn('vibrate \'none\'', response.headers['Feature-Policy'])


### PR DESCRIPTION
This fixes the code to match the docstring, allowing to pass strings *and* dicts for the Feature-Policy and Content-Security-Policy headers.