### PR TITLE
Fix handling policy directives with multiple sources.

### DIFF
--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -245,7 +245,7 @@ class Talisman(object):
 
             for policy_part in policy_string.split(';'):
                 policy_parts = policy_part.strip().split(' ')
-                policy[policy_parts[0]] = "".join(policy_parts[1:])
+                policy[policy_parts[0]] = " ".join(policy_parts[1:])
 
         policies = []
         for section, content in iteritems(policy):

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -148,10 +148,10 @@ class TestTalismanExtension(unittest.TestCase):
         self.assertIn('image-src \'self\' example.com', csp)
 
         # string policy
-        self.talisman.content_security_policy = 'default-src example.com'
+        self.talisman.content_security_policy = 'default-src \'foo\' spam.eggs'
         response = self.client.get('/', environ_overrides=HTTPS_ENVIRON)
         self.assertEqual(response.headers['Content-Security-Policy'],
-                         'default-src example.com')
+                         'default-src \'foo\' spam.eggs')
 
         # no policy
         self.talisman.content_security_policy = False
@@ -160,10 +160,10 @@ class TestTalismanExtension(unittest.TestCase):
 
         # string policy at initialization
         app = flask.Flask(__name__)
-        Talisman(app, content_security_policy='default-src spam.eggs')
+        Talisman(app, content_security_policy='default-src \'foo\' spam.eggs')
         response = app.test_client().get('/', environ_overrides=HTTPS_ENVIRON)
         self.assertIn(
-            'default-src spam.eggs',
+            'default-src \'foo\' spam.eggs',
             response.headers['Content-Security-Policy']
         )
 


### PR DESCRIPTION
This is kind of a big deal as it prevents the extension to correctly generate policy directives when multiple sources are used. (for when the policy is provided as a string, e.g. from an env var)