### PR TITLE
Set object_src to 'none'

### DIFF
--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -26,6 +26,7 @@ DEFAULT_REFERRER_POLICY = 'strict-origin-when-cross-origin'
 
 DEFAULT_CSP_POLICY = {
     'default-src': '\'self\'',
+    'object-src': '\'none\'',
 }
 
 GOOGLE_CSP_POLICY = {
@@ -39,6 +40,7 @@ GOOGLE_CSP_POLICY = {
     # Used by generated code from http://www.google.com/fonts
     'style-src': '\'self\' ajax.googleapis.com fonts.googleapis.com '
                  '*.gstatic.com',
+    'object-src': '\'none\'',
     'default-src': '\'self\' *.gstatic.com',
 }
 


### PR DESCRIPTION
object-src is a common pathway for XSS injections. I doubt most sites using Flask use archaic plug-in elements but the possibility exists. 
It's probably better explained in this paper: https://dl.acm.org/doi/pdf/10.1145/2976749.2978363
Even Google's CSP Evaluator now flags websites with a missing object-src value in their CSP.