### PR TITLE
Nonce readme fix

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -93,8 +93,8 @@ Options
 -  ``content_security_policy``, default ``default-src: 'self'``, see the
    `Content Security Policy`_ section.
 -  ``content_security_policy_nonce_in``, default ``[]``. Adds a per-request nonce
-    value to the flask request object and also to the specified CSP header section.
-    I.e. ['script-src', 'style-src']
+   value to the flask request object and also to the specified CSP header section.
+   I.e. ['script-src', 'style-src']
 -  ``content_security_policy_report_only``, default ``False``, whether to set
    the CSP header as "report-only" (as `Content-Security-Policy-Report-Only`)
    to ease deployment by disabling the policy enforcement by the browser,

--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ Options
    `Content Security Policy`_ section.
 -  ``content_security_policy_nonce_in``, default ``[]``. Adds a per-request nonce
    value to the flask request object and also to the specified CSP header section.
-   I.e. ['script-src', 'style-src']
+   I.e. ``['script-src', 'style-src']``
 -  ``content_security_policy_report_only``, default ``False``, whether to set
    the CSP header as "report-only" (as `Content-Security-Policy-Report-Only`)
    to ease deployment by disabling the policy enforcement by the browser,


### PR DESCRIPTION
Just noticed this is formatted incorrectly:

![bold italics around content_security_policy_nonce_in option](https://user-images.githubusercontent.com/10931297/84240121-71bad300-aaf5-11ea-8202-fc05579dcc35.png)

This is due to extra spaces on next two lines making it a Description List (`<dl><dt>`). So removed those spaces.

Also added some code formatting around the example.