### PR TITLE
Misc fixes to README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -312,7 +312,7 @@ The default feature policy is empty, as this is the default expected behaviour.
 Note that the Feature Policy is still a `draft https://wicg.github.io/feature-policy/`
 but is `supported in some form in most browsers
 <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Browser_compatibility>`_.
-Please note this has been `renamed Permissions Policy <https://github.com/w3c/webappsec-feature-policy/issues/359>`
+Please note this has been `renamed Permissions Policy <https://github.com/w3c/webappsec-feature-policy/issues/359>`_
 in the latest draft by at this writing, browsers and this extension only
 supports the Feature-Policy HTTP Header name.
 

--- a/README.rst
+++ b/README.rst
@@ -111,7 +111,7 @@ Options
    cookie to ``httponly``, preventing it from being read by JavaScript.
 -  ``force_file_save``, default ``False``, whether to set the
    `X-Download-Options <https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj542450(v=vs.85)?redirectedfrom=MSDN>`_
-   header to ``noopen` to prevent IE >= 8 to from opening file downloads
+   header to ``noopen`` to prevent IE >= 8 to from opening file downloads
    directly and only save them instead.
 
 Per-view options

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,11 @@ The default configuration:
    to ``SAMEORIGIN`` to avoid
    `clickjacking <https://en.wikipedia.org/wiki/Clickjacking>`_.
 -  Sets `X-XSS-Protection
-   <http://msdn.microsoft.com/en-us/library/dd565647(v=vs.85).aspx>`_ to enable
-   a cross site scripting filter for IE/Chrome.
+   <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection>`_
+   to enable a cross site scripting filter for IE.
 -  Sets `X-Content-Type-Options
-   <https://msdn.microsoft.com/library/gg622941(v=vs.85).aspx>`_ to prevents
-   content type sniffing for IE >= 9.
+   <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
+   to prevent content type sniffing.
 -  Sets a strict `Content Security
    Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy>`__
    of ``default-src: 'self'``. This is intended to almost completely
@@ -109,8 +109,9 @@ Options
 -  ``session_cookie_http_only``, default ``True``, set the session
    cookie to ``httponly``, preventing it from being read by JavaScript.
 -  ``force_file_save``, default ``False``, whether to set the
-   ``X-Download-Options`` header to ``noopen`` to prevent IE >= 8 to from
-   opening file downloads directly and only save them instead
+   `X-Download-Options <https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj542450(v=vs.85)?redirectedfrom=MSDN>`_
+   header to ``noopen` to prevent IE >= 8 to from opening file downloads
+   directly and only save them instead.
 
 Per-view options
 ~~~~~~~~~~~~~~~~
@@ -308,7 +309,11 @@ Feature Policy
 
 The default feature policy is empty, as this is the default expected behaviour.
 Note that the Feature Policy is still a `draft https://wicg.github.io/feature-policy/`
-and supported in Chrome and Safari.
+but is `supported in some form in most browsers
+<https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Browser_compatibility>`_.
+Please note this has been renamed Permissions Policy in the latest draft by at this
+writing, browsers and this extension only supports the Feature-Policy HTTP
+Header name.
 
 Geolocation Example
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -23,7 +23,8 @@ The default configuration:
    `clickjacking <https://en.wikipedia.org/wiki/Clickjacking>`_.
 -  Sets `X-XSS-Protection
    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection>`_
-   to enable a cross site scripting filter for IE.
+   to enable a cross site scripting filter for IE and Safari (note Chrome has
+   removed this and Firefox never supported it).
 -  Sets `X-Content-Type-Options
    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
    to prevent content type sniffing.
@@ -311,9 +312,9 @@ The default feature policy is empty, as this is the default expected behaviour.
 Note that the Feature Policy is still a `draft https://wicg.github.io/feature-policy/`
 but is `supported in some form in most browsers
 <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Feature-Policy#Browser_compatibility>`_.
-Please note this has been renamed Permissions Policy in the latest draft by at this
-writing, browsers and this extension only supports the Feature-Policy HTTP
-Header name.
+Please note this has been `renamed Permissions Policy <https://github.com/w3c/webappsec-feature-policy/issues/359>`
+in the latest draft by at this writing, browsers and this extension only
+supports the Feature-Policy HTTP Header name.
 
 Geolocation Example
 ~~~~~~~~~~~~~~~~~~~

--- a/README.rst
+++ b/README.rst
@@ -27,9 +27,6 @@ The default configuration:
 -  Sets `X-Content-Type-Options
    <https://msdn.microsoft.com/library/gg622941(v=vs.85).aspx>`_ to prevents
    content type sniffing for IE >= 9.
--  Sets `X-Download-Options
-   <https://msdn.microsoft.com/library/jj542450(v=vs.85).aspx>`_ to prevent
-   file downloads opening for IE >= 8.
 -  Sets a strict `Content Security
    Policy <https://developer.mozilla.org/en-US/docs/Web/Security/CSP/Introducing_Content_Security_Policy>`__
    of ``default-src: 'self'``. This is intended to almost completely
@@ -70,7 +67,7 @@ There is also a full `Example App <https://github.com/GoogleCloudPlatform/flask-
 Options
 -------
 
--  ``feature_policy``, default ``{}``, see the `Feature Policy` section.
+-  ``feature_policy``, default ``{}``, see the `Feature Policy`_ section.
 -  ``force_https``, default ``True``, forces all non-debug connects to
    ``https``.
 -  ``force_https_permanent``, default ``False``, uses ``301`` instead of


### PR DESCRIPTION
This makes a few changes to the README:

- Changes from MSDN to MDN as more universally used. The one exception is X-Download-Options which is not on MDN as MS specific.
- Adds note about X-XSS-Protection support.
- Removes note about >=IE9 for x-Content-Type-Options as not just IE
- Removed X-Download-Options from default config as this is not correct - closes #43 
- Fixes Feature Policy link
- Adds some more info about Feature Policy as not just Chrome and Safari now, and also looks like this has been renamed Permission Policy (though browsers don't support this yet so this extension shouldn't either).
