### PR TITLE
Explicit disable (unsafe) `X-XSS-Protection`-header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,10 +21,9 @@ The default configuration:
    `X-Frame-Options <https://developer.mozilla.org/en-US/docs/Web/HTTP/X-Frame-Options>`_
    to ``SAMEORIGIN`` to avoid
    `clickjacking <https://en.wikipedia.org/wiki/Clickjacking>`_.
--  Sets `X-XSS-Protection
+-  Explicit disables `X-XSS-Protection
    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection>`_
-   to enable a cross site scripting filter for IE and Safari (note Chrome has
-   removed this and Firefox never supported it).
+   to avoid introducing unintended vulnerabilities in otherwise safe code.
 -  Sets `X-Content-Type-Options
    <https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options>`_
    to prevent content type sniffing.

--- a/flask_talisman/talisman.py
+++ b/flask_talisman/talisman.py
@@ -284,7 +284,11 @@ class Talisman(object):
                 options['frame_options_allow_from'])
 
     def _set_content_security_policy_headers(self, headers, options):
-        headers['X-XSS-Protection'] = '1; mode=block'
+        # Yes, this is correct.  The X-XSS-Protection header is deprecated and
+        # can actually introduce vulnerabilities in otherwise safe code, so lets
+        # explicit disable it.  Ref: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection
+        headers['X-XSS-Protection'] = '0'
+
         headers['X-Content-Type-Options'] = 'nosniff'
 
         if self.force_file_save:

--- a/flask_talisman/talisman_test.py
+++ b/flask_talisman/talisman_test.py
@@ -52,7 +52,7 @@ class TestTalismanExtension(unittest.TestCase):
             'X-Frame-Options': 'SAMEORIGIN',
             'Strict-Transport-Security':
             'max-age=31556926; includeSubDomains',
-            'X-XSS-Protection': '1; mode=block',
+            'X-XSS-Protection': '0',
             'X-Content-Type-Options': 'nosniff',
             'Content-Security-Policy': 'default-src \'self\'',
             'Referrer-Policy': 'strict-origin-when-cross-origin'


### PR DESCRIPTION
A bit counter-intuitive, but `X-XSS-Protection` is actually dangerous on (old) browsers supporting the spec.

In _filtering_ mode it easily allows attackers to remove critical blocks of JavaScript, which can introduce vulnerabilities in otherwise safe code: [PoC](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-XSS-Protection#vulnerabilities_caused_by_xss_filtering).

In _blocking_ mode it can be used as an side-channel oracle, leaking cross origin bodies/tokens: [theory](https://portswigger.net/research/abusing-chromes-xss-auditor-to-steal-tokens) / [PoC](https://www.youtube.com/watch?v=HcrQy0C-hEA)

Hot take, this is a terrible header that shouldn't be included.  In this PR I explicit disable it, but this PR could also easily be refactored to completely remove the header.

Disabling it on modern browsers does nothing, as it is already disabled.